### PR TITLE
Added a constant AUTO_SAVE that can be manually set

### DIFF
--- a/src/vbaDeveloper.xlam/Build.bas
+++ b/src/vbaDeveloper.xlam/Build.bas
@@ -134,7 +134,7 @@ Private Function hasCodeToExport(component As VBComponent) As Boolean
     hasCodeToExport = True
     If component.codeModule.CountOfLines <= 2 Then
         Dim firstLine As String
-        firstLine = Trim(component.codeModule.lines(1, 1))
+        firstLine = Trim(component.codeModule.Lines(1, 1))
         'Debug.Print firstLine
         hasCodeToExport = Not (firstLine = "" Or firstLine = "Option Explicit")
     End If
@@ -158,7 +158,7 @@ Private Sub exportLines(exportPath As String, component As VBComponent)
     Dim fso As New Scripting.FileSystemObject
     Dim outStream As TextStream
     Set outStream = fso.CreateTextFile(fileName, True, False)
-    outStream.Write (component.codeModule.lines(1, component.codeModule.CountOfLines))
+    outStream.Write (component.codeModule.Lines(1, component.codeModule.CountOfLines))
     outStream.Close
 End Sub
 
@@ -218,7 +218,7 @@ Private Sub checkHowToImport(file As Object, includeClassFiles As Boolean)
     Dim fileName As String
     fileName = file.name
     Dim componentName As String
-    componentName = left(fileName, InStr(fileName, ".") - 1)
+    componentName = Left(fileName, InStr(fileName, ".") - 1)
     If componentName = "Build" Then
         '"don't remove or import ourself
         Exit Sub
@@ -226,10 +226,10 @@ Private Sub checkHowToImport(file As Object, includeClassFiles As Boolean)
 
     If Len(fileName) > 4 Then
         Dim lastPart As String
-        lastPart = right(fileName, 4)
+        lastPart = Right(fileName, 4)
         Select Case lastPart
             Case ".cls" ' 10 == Len(".sheet.cls")
-                If Len(fileName) > 10 And right(fileName, 10) = ".sheet.cls" Then
+                If Len(fileName) > 10 And Right(fileName, 10) = ".sheet.cls" Then
                     'import lines into sheet: importLines vbaProjectToImport, file
                     sheetsToImport.Add componentName, file
                 Else
@@ -297,7 +297,7 @@ End Sub
 
 Private Sub importLines(vbaProject As VBProject, file As Object)
     Dim componentName As String
-    componentName = left(file.name, InStr(file.name, ".") - 1)
+    componentName = Left(file.name, InStr(file.name, ".") - 1)
     Dim c As VBComponent
     If Not componentExists(vbaProject, componentName) Then
         ' Create a sheet to import this code into. We cannot set the ws.codeName property which is read-only,

--- a/src/vbaDeveloper.xlam/EventListener.cls
+++ b/src/vbaDeveloper.xlam/EventListener.cls
@@ -21,6 +21,7 @@ End Sub
 
 Private Sub App_WorkbookAfterSave(ByVal wb As Workbook, ByVal success As Boolean)
     On Error GoTo App_WorkbookAfterSave_Error
+	If AUTO_SAVE = "Yes" Then   'This is set manually in the 'Build' macro so that users can choose whether they want autosave enabled.
 
     'Export all the modules for this work book if save was successful
     If success Then
@@ -44,6 +45,8 @@ End Sub
 
 Private Sub App_WorkbookOpen(ByVal wb As Workbook)
     On Error GoTo App_WorkbookOpen_Error
+
+	If AUTO_SAVE = "Yes" Then   'This is set manually in the 'Build' macro so that users can choose whether they want autosave enabled.
 
     'Import all the modules for this workbook
     Dim importNow As Integer


### PR DESCRIPTION
Added a constant AUTO_SAVE that can be manually set in the Build file to allow for exporting upon save to be set as default or manual.  Future ideas could be to add this as a toggle menu item so it can be turned on and off more easily.  I don't have much time for it right now so I submitted a simple fix which actually wasn't mine.

Basically, I took part of the code that NealHumphrey submitted as a pull request and applied it to the latest branch.  I too have a desire to set autosave or not so I figured I'd help out a little on that end.

NOTE: some of the native functions had title-case applied to them automatically by the VBA Project IDE.  Aside from those, it's simply three lines of code added.