### PR TITLE
Fix build instructions for non-English Microsoft Excel version

### DIFF
--- a/src/vbaDeveloper.xlam/Build.bas
+++ b/src/vbaDeveloper.xlam/Build.bas
@@ -10,11 +10,13 @@ Attribute VB_Name = "Build"
 ' 5. Enable programatic access to VBA:
 '       File -> Options -> Trust Center, Trust Center Settings, -> Macros,
 '       tick the box: 'Enable programatic access to VBA'  (In excel 2010: 'Trust access to the vba project object model')
-' 6. In VB Editor, press F4, then under Microsoft Excel Objects, select ThisWorkbook.Set the property 'IsAddin' to TRUE
-' 7. In VB Editor, menu File-->Save Book1; Save as vbaDeveloper.xlam in the same directory as 'src'
-' 8. Close excel. Open excel with a new workbook, then open the just saved vbaDeveloper.xlam
-' 9. Let vbaDeveloper import its own code. Put the cursor in the function 'testImport' and press F5
-' 10.If necessary rename module 'Build1' to Build. Menu File-->Save vbaDeveloper.xlam
+' 6. If using a non-English version of Excel, rename your current workbook into ThisWorkbook (in VB Editor, press F4,
+'    then under the local name for Microsoft Excel Objects, select the workbook. Set the property '(Name)' to ThisWorkbook)
+' 7. In VB Editor, press F4, then under Microsoft Excel Objects, select ThisWorkbook.Set the property 'IsAddin' to TRUE
+' 8. In VB Editor, menu File-->Save Book1; Save as vbaDeveloper.xlam in the same directory as 'src'
+' 9. Close excel. Open excel with a new workbook, then open the just saved vbaDeveloper.xlam
+' 10.Let vbaDeveloper import its own code. Put the cursor in the function 'testImport' and press F5
+' 11.If necessary rename module 'Build1' to Build. Menu File-->Save vbaDeveloper.xlam
 '''
 
 Option Explicit


### PR DESCRIPTION
With non-English versions, testImport creates a new worksheet named
ThisWorkbook and imports the code there instead of importing the
code into the current Workbook ThisWorkbook: 
![wrongimport](https://cloud.githubusercontent.com/assets/19879328/16148287/eaa8c476-3488-11e6-910f-6724792730cd.jpg)
To prevent this, you'll have to rename the workbook in VB Editor
from your local name (e.g. DieseArbeitsmappe in German) into ThisWorkbook.