### PR TITLE
Fix "Menu.exportVbProject" "CodeModule" runtime error -2147467259

### DIFF
--- a/src/vbaDeveloper.xlam/Build.bas
+++ b/src/vbaDeveloper.xlam/Build.bas
@@ -147,13 +147,30 @@ Public Sub exportVbaCode(vbaProject As VBProject)
 End Sub
 
 
+Private Function codeModuleExists(component As VBComponent) As Boolean
+    On Error GoTo doesnt
+    Dim tempObj
+    Set tempObj = component.codeModule
+    codeModuleExists = True
+    Exit Function
+doesnt:
+    On Error GoTo -1
+    Err.Clear
+    codeModuleExists = False
+    Exit Function
+End Function
+
+
 Private Function hasCodeToExport(component As VBComponent) As Boolean
     hasCodeToExport = True
-    If component.codeModule.CountOfLines <= 2 Then
-        Dim firstLine As String
-        firstLine = Trim(component.codeModule.lines(1, 1))
-        'Debug.Print firstLine
-        hasCodeToExport = Not (firstLine = "" Or firstLine = "Option Explicit")
+    If codeModuleExists(component) Then
+        If component.codeModule.CountOfLines <= 2 Then
+            Dim firstLine As String
+            firstLine = Trim(component.codeModule.lines(1, 1))
+            'Debug.Print firstLine
+            hasCodeToExport = Not (firstLine = "" Or firstLine = "Option Explicit")
+    Else
+        hasCodeToExport = False
     End If
 End Function
 


### PR DESCRIPTION
Prevents access to unexisting "codeModule" property of "project" "ThisWorkbook" when exporting via "VbaDeveloper > Export code for... > VBAProject (...)".

## Original error message after trying to export
![workbook](https://user-images.githubusercontent.com/67320964/85405580-06cabc80-b537-11ea-9099-4a4ee33a56dd.png)

## Debugging the previous error 
![XLAM](https://user-images.githubusercontent.com/67320964/85405596-0b8f7080-b537-11ea-95be-443ed82ab01c.png)

## Fix
The fix consists of simply checking for the existence of the `codeModule` property before access.
